### PR TITLE
Add User Name Step to Onboarding

### DIFF
--- a/app/Utils/OnBoardingSteps.php
+++ b/app/Utils/OnBoardingSteps.php
@@ -7,8 +7,9 @@ use Exception;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Storage;
-
+use Illuminate\Support\Facades\Cache;
 use function Laravel\Prompts\password;
+use function Laravel\Prompts\input;
 
 class OnBoardingSteps
 {
@@ -134,5 +135,17 @@ class OnBoardingSteps
         }
 
         return false;
+    }
+
+    public function requestUserName(): string
+    {
+        $userName = input(
+            label: "👤: Enter your name",
+            placeholder: 'John Doe'
+        );
+
+        Cache::put('user_name', $userName);
+
+        return $userName;
     }
 }


### PR DESCRIPTION
This PR introduces a new step in the onboarding process to request and save the user's name to cache. The changes include:

1. Added a new method  in  that prompts for the user's name and stores it in cache.
2. Updated the  method to include the new step.

This ensures that we capture the user's name during onboarding, enhancing personalization of the assistant.