### PR TITLE
Fix: Ensure new assistant updates current project assistant

### DIFF
--- a/app/Commands/DexorCommand.php
+++ b/app/Commands/DexorCommand.php
@@ -7,7 +7,7 @@ use App\Tools\ExecuteCommand;
 use App\Utils\OnBoardingSteps;
 use Exception;
 use Illuminate\Console\Command;
-
+use App\Models\Assistant;
 use function Termwind\ask;
 
 class DexorCommand extends Command
@@ -34,7 +34,9 @@ class DexorCommand extends Command
         }
 
         if ($this->option('new')) {
-            $this->chatAssistant->createNewAssistant();
+            $assistant = $this->chatAssistant->createNewAssistant();
+            Assistant::query()->update(['current' => false]);
+            $assistant->update(['current' => true]);
         }
 
         $thread = $this->chatAssistant->createThread();

--- a/tests/Unit/DexorCommandTest.php
+++ b/tests/Unit/DexorCommandTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Commands\DexorCommand;
+use App\Models\Assistant;
+use App\Services\ChatAssistant;
+use App\Tools\ExecuteCommand;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DexorCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_new_command_creates_and_updates_assistant()
+    {
+        $chatAssistant = $this->createMock(ChatAssistant::class);
+        $executeCommand = $this->createMock(ExecuteCommand::class);
+        $command = new DexorCommand($chatAssistant, $executeCommand);
+
+        $assistant = Assistant::factory()->create(['current' => false]);
+
+        // Mock the createNewAssistant method
+        $newAssistant = $this->createMock(Assistant::class);
+        $chatAssistant->method('createNewAssistant')->willReturn($newAssistant);
+        $newAssistant->expects($this->once())->method('update')->with(['current' => true]);
+
+        $this->artisan('dexor --new');
+
+        $this->assertFalse($assistant->fresh()->current);
+    }
+}


### PR DESCRIPTION
This PR fixes the issue where a new assistant created via `dexor --new` does not update the current project assistant. Unit test added to verify the functionality.