### PR TITLE
Fix: Cross-platform home directory detection for Windows compatibility

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -34,7 +34,7 @@ return [
         'sqlite' => [
             'driver' => 'sqlite',
             'url' => env('DB_URL'),
-            'database' => env('DB_DATABASE', $_SERVER['HOME'].'/.dexor/'.'database.sqlite'),
+            'database' => env('DB_DATABASE', (isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['USERPROFILE']).'/.dexor/'.'database.sqlite'),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],

--- a/config/database.php
+++ b/config/database.php
@@ -34,7 +34,7 @@ return [
         'sqlite' => [
             'driver' => 'sqlite',
             'url' => env('DB_URL'),
-            'database' => env('DB_DATABASE', (isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['USERPROFILE']).'/.dexor/'.'database.sqlite'),
+            'database' => env('DB_DATABASE', ($_SERVER['HOME'] ?? $_SERVER['USERPROFILE']).'/.dexor/'.'database.sqlite'),
             'prefix' => '',
             'foreign_key_constraints' => env('DB_FOREIGN_KEYS', true),
         ],

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -9,11 +9,11 @@ return [
         ],
         'home' => [
             'driver' => 'local',
-            'root' => $_SERVER['HOME'].'/.dexor',
+            'root' => (isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['USERPROFILE']).'/.dexor',
         ],
         'root' => [
             'driver' => 'local',
-            'root' => $_SERVER['HOME'],
+            'root' => isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['USERPROFILE'],
         ],
         'internal' => [//phar and local
             'driver' => 'local',

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -9,11 +9,11 @@ return [
         ],
         'home' => [
             'driver' => 'local',
-            'root' => (isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['USERPROFILE']).'/.dexor',
+            'root' => ($_SERVER['HOME'] ?? $_SERVER['USERPROFILE']).'/.dexor',
         ],
         'root' => [
             'driver' => 'local',
-            'root' => isset($_SERVER['HOME']) ? $_SERVER['HOME'] : $_SERVER['USERPROFILE'],
+            'root' => $_SERVER['HOME'] ?? $_SERVER['USERPROFILE'],
         ],
         'internal' => [//phar and local
             'driver' => 'local',


### PR DESCRIPTION
This pull request addresses the issue #32 where the application doesn't run on Windows due to undefined 'HOME' environment variable.

Changes made:

1. Updated `config/database.php` to use a cross-platform way of detecting the home directory.
2. Updated `config/filesystems.php` to use a cross-platform way of detecting the home directory.

The fix involves using both `$_SERVER['HOME']` and `$_SERVER['USERPROFILE']` to ensure compatibility with both Unix-like systems and Windows. This approach allows the application to find the correct home directory regardless of the operating system.

Why this is a fix:
- Windows uses 'USERPROFILE' instead of 'HOME' for the user's home directory.
- By checking for both variables, we ensure that the application can run on both Unix-like systems and Windows without throwing errors related to the 'HOME' environment variable.

Testing:
1. Windows users should update their global installation of the package:
   
2. Run the `dexor` command.

The application should now run without throwing any errors related to the 'HOME' environment variable.

This fix improves the cross-platform compatibility of the application and resolves the issue reported by Windows users.

Closes #32